### PR TITLE
Fix initialization in plain JS Meddicc tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app.js
+++ b/app.js
@@ -424,7 +424,12 @@ class MeddiccTool {
     }
 }
 
-// Initialize the application
-document.addEventListener('DOMContentLoaded', () => {
+// Initialize the application even if DOMContentLoaded has already fired
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+        new MeddiccTool();
+    });
+} else {
+    // Document is already parsed, safe to initialize immediately
     new MeddiccTool();
-});
+}


### PR DESCRIPTION
## Summary
- handle case where `DOMContentLoaded` already fired before `app.js` executes
- ignore `node_modules`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683bda2e50c08329b8fca3e3acba3c9c