### PR TITLE
Fix initialization in plain JS Meddicc tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app.js
+++ b/app.js
@@ -424,7 +424,13 @@ class MeddiccTool {
     }
 }
 
-// Initialize the application
-document.addEventListener('DOMContentLoaded', () => {
+// Initialize the application when DOM is ready
+function initMeddicc() {
     new MeddiccTool();
-});
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initMeddicc);
+} else {
+    initMeddicc();
+}

--- a/index.html
+++ b/index.html
@@ -114,6 +114,6 @@
         </footer>
     </div>
 
-    <script src="app.js"></script>
+    <script src="app.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure `app.js` waits for DOM before starting
- load script with `defer` to avoid blank screen

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683bda2e50c08329b8fca3e3acba3c9c